### PR TITLE
Fix for render/opengl_driver/tests/complex/draw_indexed test

### DIFF
--- a/components/render/opengl_driver/tests/complex/draw_indexed.cpp
+++ b/components/render/opengl_driver/tests/complex/draw_indexed.cpp
@@ -17,21 +17,38 @@ struct MyVertex
   Color4ub color;
 };
 
-void redraw (Test& test)
+class DrawIndexedApplication
 {
-  test.device->GetImmediateContext ()->DrawIndexed (PrimitiveType_TriangleList, 0, 3, 0);
-}
+  TestPtr        test;
+  BufferPtr      vb;
+  BufferPtr      ib;
+  InputLayoutPtr layout;
 
-int main ()
-{
-  printf ("Results of draw_indexed_test:\n");
-
-  try
+  static void Redraw (Test& test)
   {
-    Test test (L"OpenGL device test window (draw_indexed)", &redraw);
+    test.device->GetImmediateContext ()->DrawIndexed (PrimitiveType_TriangleList, 0, 3, 0);
+  }
 
-    test.window.Show ();
+  void OnInitialize ()
+  {
+    test = new Test(L"OpenGL device test window (draw_indexed)", &Redraw);
 
+    test->window.Show ();
+
+    CreateVertexBuffer ();
+    CreateIndexBuffer ();
+    SetInputStage ();
+  }
+
+  void OnExit ()
+  {
+    // Test object should be destroyed
+    // BEFORE application exit.
+    test.reset ();
+  }
+
+  void CreateVertexBuffer ()
+  {
     printf ("Create vertex buffer\n");
 
     static const size_t VERTICES_COUNT = 3;
@@ -45,7 +62,7 @@ int main ()
     vb_desc.bind_flags   = BindFlag_VertexBuffer;
     vb_desc.access_flags = AccessFlag_Read | AccessFlag_Write;
 
-    BufferPtr vb (test.device->CreateBuffer (vb_desc), false);
+    vb = BufferPtr (test->device->CreateBuffer (vb_desc), false);
 
     static const MyVertex verts [] = {
       {{-1, -1, 0}, {0, 0, 1}, {255, 0, 0, 0}},
@@ -54,7 +71,10 @@ int main ()
     };
 
     vb->SetData (0, vb_desc.size, verts);
+  }
 
+  void CreateIndexBuffer()
+  {
     printf ("Create index buffer\n");
 
     static unsigned short indices [] = {0, 1, 2};
@@ -68,16 +88,40 @@ int main ()
     ib_desc.bind_flags   = BindFlag_IndexBuffer;
     ib_desc.access_flags = AccessFlag_ReadWrite;
 
-    BufferPtr ib (test.device->CreateBuffer (ib_desc), false);
+    ib = BufferPtr (test->device->CreateBuffer (ib_desc), false);
 
     ib->SetData (0, ib_desc.size, indices);
+  }
 
+  void SetInputStage ()
+  {
     printf ("Set input-stage\n");
 
     VertexAttribute attributes [] = {
-      {test.device->GetVertexAttributeSemanticName (VertexAttributeSemantic_Normal), InputDataFormat_Vector3, InputDataType_Float, 0, offsetof (MyVertex, normal), sizeof (MyVertex)},
-      {test.device->GetVertexAttributeSemanticName (VertexAttributeSemantic_Position), InputDataFormat_Vector3, InputDataType_Float, 0, offsetof (MyVertex, position), sizeof (MyVertex)},
-      {test.device->GetVertexAttributeSemanticName (VertexAttributeSemantic_Color), InputDataFormat_Vector4, InputDataType_UByte, 0, offsetof (MyVertex, color), sizeof (MyVertex)},
+      {
+          test->device->GetVertexAttributeSemanticName (VertexAttributeSemantic_Normal)
+        , InputDataFormat_Vector3
+        , InputDataType_Float
+        , 0
+        , offsetof (MyVertex, normal)
+        , sizeof (MyVertex)
+      },
+      {
+          test->device->GetVertexAttributeSemanticName (VertexAttributeSemantic_Position)
+        , InputDataFormat_Vector3
+        , InputDataType_Float
+        , 0
+        , offsetof (MyVertex, position)
+        , sizeof (MyVertex)
+      },
+      {
+          test->device->GetVertexAttributeSemanticName (VertexAttributeSemantic_Color)
+        , InputDataFormat_Vector4
+        , InputDataType_UByte
+        , 0
+        , offsetof (MyVertex, color)
+        , sizeof (MyVertex)
+      },
     };
 
     InputLayoutDesc layout_desc;
@@ -89,19 +133,49 @@ int main ()
     layout_desc.index_type              = InputDataType_UShort;
     layout_desc.index_buffer_offset     = 0;
 
-    InputLayoutPtr layout (test.device->CreateInputLayout (layout_desc), false);
+    layout = InputLayoutPtr (test->device->CreateInputLayout (layout_desc), false);
 
-    test.device->GetImmediateContext ()->ISSetInputLayout (layout.get ());
-    test.device->GetImmediateContext ()->ISSetVertexBuffer (0, vb.get ());
-    test.device->GetImmediateContext ()->ISSetIndexBuffer (ib.get ());
+    test->device->GetImmediateContext ()->ISSetInputLayout (layout.get ());
+    test->device->GetImmediateContext ()->ISSetVertexBuffer (0, vb.get ());
+    test->device->GetImmediateContext ()->ISSetIndexBuffer (ib.get ());
+  }
 
+public:
+  DrawIndexedApplication ()
+  {
+    syslib::Application::RegisterEventHandler (
+        syslib::ApplicationEvent_OnInitialize
+      , xtl::bind(&DrawIndexedApplication::OnInitialize, this)
+    );
+
+    syslib::Application::RegisterEventHandler (
+        syslib::ApplicationEvent_OnExit
+      , xtl::bind(&DrawIndexedApplication::OnExit, this)
+    );
+  }
+
+  void Run ()
+  {
     printf ("Main loop\n");
 
     syslib::Application::Run ();
   }
+};
+
+int main ()
+{
+  printf ("Results of draw_indexed_test:\n");
+
+  try
+  {
+    DrawIndexedApplication app;
+
+    app.Run ();
+  }
   catch (std::exception& e)
   {
     printf ("exception: %s\n", e.what ());
+    return 1;
   }
 
   return 0;

--- a/components/render/opengl_driver/tests/complex/shared.h
+++ b/components/render/opengl_driver/tests/complex/shared.h
@@ -20,6 +20,7 @@
 
 #include <stl/string>
 #include <stl/hash_map>
+#include <stl/auto_ptr.h>
 
 #include <xtl/intrusive_ptr.h>
 #include <xtl/iterator.h>
@@ -200,6 +201,8 @@ struct Test
     syslib::Application::Exit (0);
   }
 };
+
+typedef stl::auto_ptr<Test> TestPtr;
 
 //чтение ихсодного текста шейдера в строку
 stl::string read_shader (const char* file_name)


### PR DESCRIPTION
This patch fixes the following issue:

```
exception: Can't create window before application start (Message queue singleton is not initialized)
    at syslib::XlibWindowManager::CreateWindow
    at syslib::Window::Impl::Init
    at syslib::Window::Init(WindowStyle)
    at syslib::Window::Init(WindowStyle,unsigned int,unsigned int)
    at syslib::Window::Window(WindowStyle,unsigned int,unsigned int)
```