### PR TITLE
Fix for render/opengl_driver/tests/complex/window_resize test

### DIFF
--- a/components/render/opengl_driver/tests/complex/draw_indexed.cpp
+++ b/components/render/opengl_driver/tests/complex/draw_indexed.cpp
@@ -31,13 +31,21 @@ class DrawIndexedApplication
 
   void OnInitialize ()
   {
-    test = new Test(L"OpenGL device test window (draw_indexed)", &Redraw);
+    try
+    {
+      test = new Test(L"OpenGL device test window (draw_indexed)", &Redraw);
 
-    test->window.Show ();
+      test->window.Show ();
 
-    CreateVertexBuffer ();
-    CreateIndexBuffer ();
-    SetInputStage ();
+      CreateVertexBuffer ();
+      CreateIndexBuffer ();
+      SetInputStage ();
+    }
+    catch (const xtl::exception& e)
+    {
+      printf("%s failed: %s\n", __FUNCTION__, e.what());
+      syslib::Application::Exit (1);
+    }
   }
 
   void OnExit ()
@@ -49,95 +57,119 @@ class DrawIndexedApplication
 
   void CreateVertexBuffer ()
   {
-    printf ("Create vertex buffer\n");
+    try
+    {
+      printf ("Create vertex buffer\n");
 
-    static const size_t VERTICES_COUNT = 3;
+      static const size_t VERTICES_COUNT = 3;
 
-    BufferDesc vb_desc;
+      BufferDesc vb_desc;
 
-    memset (&vb_desc, 0, sizeof vb_desc);
+      memset (&vb_desc, 0, sizeof vb_desc);
 
-    vb_desc.size         = sizeof (MyVertex) * VERTICES_COUNT;
-    vb_desc.usage_mode   = UsageMode_Default;
-    vb_desc.bind_flags   = BindFlag_VertexBuffer;
-    vb_desc.access_flags = AccessFlag_Read | AccessFlag_Write;
+      vb_desc.size         = sizeof (MyVertex) * VERTICES_COUNT;
+      vb_desc.usage_mode   = UsageMode_Default;
+      vb_desc.bind_flags   = BindFlag_VertexBuffer;
+      vb_desc.access_flags = AccessFlag_Read | AccessFlag_Write;
 
-    vb = BufferPtr (test->device->CreateBuffer (vb_desc), false);
+      vb = BufferPtr (test->device->CreateBuffer (vb_desc), false);
 
-    static const MyVertex verts [] = {
-      {{-1, -1, 0}, {0, 0, 1}, {255, 0, 0, 0}},
-      {{ 1, -1, 0}, {0, 0, 1}, {0, 255, 0, 0}},
-      {{ 0, 1, 0}, {0, 0, 1}, {0, 0, 255, 0}},
-    };
+      static const MyVertex verts [] = {
+        {{-1, -1, 0}, {0, 0, 1}, {255, 0, 0, 0}},
+        {{ 1, -1, 0}, {0, 0, 1}, {0, 255, 0, 0}},
+        {{ 0, 1, 0}, {0, 0, 1}, {0, 0, 255, 0}},
+      };
 
-    vb->SetData (0, vb_desc.size, verts);
+      vb->SetData (0, vb_desc.size, verts);
+    }
+    catch (xtl::exception& e)
+    {
+      e.touch (__FUNCTION__);
+      throw;
+    }
   }
 
   void CreateIndexBuffer()
   {
-    printf ("Create index buffer\n");
+    try
+    {
+      printf ("Create index buffer\n");
 
-    static unsigned short indices [] = {0, 1, 2};
+      static unsigned short indices [] = {0, 1, 2};
 
-    BufferDesc ib_desc;
+      BufferDesc ib_desc;
 
-    memset (&ib_desc, 0, sizeof ib_desc);
+      memset (&ib_desc, 0, sizeof ib_desc);
 
-    ib_desc.size         = sizeof indices;
-    ib_desc.usage_mode   = UsageMode_Default;
-    ib_desc.bind_flags   = BindFlag_IndexBuffer;
-    ib_desc.access_flags = AccessFlag_ReadWrite;
+      ib_desc.size         = sizeof indices;
+      ib_desc.usage_mode   = UsageMode_Default;
+      ib_desc.bind_flags   = BindFlag_IndexBuffer;
+      ib_desc.access_flags = AccessFlag_ReadWrite;
 
-    ib = BufferPtr (test->device->CreateBuffer (ib_desc), false);
+      ib = BufferPtr (test->device->CreateBuffer (ib_desc), false);
 
-    ib->SetData (0, ib_desc.size, indices);
+      ib->SetData (0, ib_desc.size, indices);
+    }
+    catch (xtl::exception& e)
+    {
+      e.touch (__FUNCTION__);
+      throw;
+    }
   }
 
   void SetInputStage ()
   {
-    printf ("Set input-stage\n");
+    try
+    {
+      printf ("Set input-stage\n");
 
-    VertexAttribute attributes [] = {
-      {
-          test->device->GetVertexAttributeSemanticName (VertexAttributeSemantic_Normal)
-        , InputDataFormat_Vector3
-        , InputDataType_Float
-        , 0
-        , offsetof (MyVertex, normal)
-        , sizeof (MyVertex)
-      },
-      {
-          test->device->GetVertexAttributeSemanticName (VertexAttributeSemantic_Position)
-        , InputDataFormat_Vector3
-        , InputDataType_Float
-        , 0
-        , offsetof (MyVertex, position)
-        , sizeof (MyVertex)
-      },
-      {
-          test->device->GetVertexAttributeSemanticName (VertexAttributeSemantic_Color)
-        , InputDataFormat_Vector4
-        , InputDataType_UByte
-        , 0
-        , offsetof (MyVertex, color)
-        , sizeof (MyVertex)
-      },
-    };
+      VertexAttribute attributes [] = {
+        {
+            test->device->GetVertexAttributeSemanticName (VertexAttributeSemantic_Normal)
+          , InputDataFormat_Vector3
+          , InputDataType_Float
+          , 0
+          , offsetof (MyVertex, normal)
+          , sizeof (MyVertex)
+        },
+        {
+            test->device->GetVertexAttributeSemanticName (VertexAttributeSemantic_Position)
+          , InputDataFormat_Vector3
+          , InputDataType_Float
+          , 0
+          , offsetof (MyVertex, position)
+          , sizeof (MyVertex)
+        },
+        {
+            test->device->GetVertexAttributeSemanticName (VertexAttributeSemantic_Color)
+          , InputDataFormat_Vector4
+          , InputDataType_UByte
+          , 0
+          , offsetof (MyVertex, color)
+          , sizeof (MyVertex)
+        },
+      };
 
-    InputLayoutDesc layout_desc;
+      InputLayoutDesc layout_desc;
 
-    memset (&layout_desc, 0, sizeof layout_desc);
+      memset (&layout_desc, 0, sizeof layout_desc);
 
-    layout_desc.vertex_attributes_count = sizeof attributes / sizeof *attributes;
-    layout_desc.vertex_attributes       = attributes;
-    layout_desc.index_type              = InputDataType_UShort;
-    layout_desc.index_buffer_offset     = 0;
+      layout_desc.vertex_attributes_count = sizeof attributes / sizeof *attributes;
+      layout_desc.vertex_attributes       = attributes;
+      layout_desc.index_type              = InputDataType_UShort;
+      layout_desc.index_buffer_offset     = 0;
 
-    layout = InputLayoutPtr (test->device->CreateInputLayout (layout_desc), false);
+      layout = InputLayoutPtr (test->device->CreateInputLayout (layout_desc), false);
 
-    test->device->GetImmediateContext ()->ISSetInputLayout (layout.get ());
-    test->device->GetImmediateContext ()->ISSetVertexBuffer (0, vb.get ());
-    test->device->GetImmediateContext ()->ISSetIndexBuffer (ib.get ());
+      test->device->GetImmediateContext ()->ISSetInputLayout (layout.get ());
+      test->device->GetImmediateContext ()->ISSetVertexBuffer (0, vb.get ());
+      test->device->GetImmediateContext ()->ISSetIndexBuffer (ib.get ());
+    }
+    catch (xtl::exception& e)
+    {
+      e.touch (__FUNCTION__);
+      throw;
+    }
   }
 
 public:

--- a/components/render/opengl_driver/tests/complex/model_load_ffp.cpp
+++ b/components/render/opengl_driver/tests/complex/model_load_ffp.cpp
@@ -414,12 +414,20 @@ class ModelLoadApplication
 
   void OnInitialize ()
   {
-    test = new Test (L"OpenGL device test window (model_load)", xtl::bind(&ModelLoadApplication::OnRedraw, this, _1));
+    try
+    {
+      test = new Test (L"OpenGL device test window (model_load)", xtl::bind(&ModelLoadApplication::OnRedraw, this, _1));
 
-    test->window.Show ();
+      test->window.Show ();
 
-    LoadModel (MODEL_NAME);
-    SetShaderStage ();
+      LoadModel (MODEL_NAME);
+      SetShaderStage ();
+    }
+    catch (const xtl::exception& e)
+    {
+      printf("%s failed: %s\n", __FUNCTION__, e.what());
+      syslib::Application::Exit (1);
+    }
   }
 
   void OnExit ()
@@ -500,9 +508,17 @@ class ModelLoadApplication
 
   void LoadModel (const char* file_name)
   {
-    printf ("Load model '%s':\n", file_name);
+    try
+    {
+      printf ("Load model '%s':\n", file_name);
   
-    model = ModelPtr (new Model (test->device, file_name));
+      model = ModelPtr (new Model (test->device, file_name));
+    }
+    catch (xtl::exception& e)
+    {
+      e.touch (__FUNCTION__);
+      throw;
+    }
   }
 
   void SetShaderStage()
@@ -552,10 +568,10 @@ class ModelLoadApplication
       test->device->GetImmediateContext ()->SSSetProgramParametersLayout (program_parameters_layout.get ());
       test->device->GetImmediateContext ()->SSSetConstantBuffer (0, cb.get ());
     }
-    catch (const std::exception& ex)
+    catch (xtl::exception& e)
     {
-      printf("%s failed: %s\n", __FUNCTION__, ex.what());
-      syslib::Application::Exit (0);
+      e.touch (__FUNCTION__);
+      throw;
     }
   }
 


### PR DESCRIPTION
This patch fixes the following issue:

```
exception: Can't create window before application start (Message queue singleton is not initialized)
    at syslib::XlibWindowManager::CreateWindow
    at syslib::Window::Impl::Init
    at syslib::Window::Init(WindowStyle)
    at syslib::Window::Init(WindowStyle,unsigned int,unsigned int)
    at syslib::Window::Window(WindowStyle,unsigned int,unsigned int)
```