### PR TITLE
Disable strict-aliasing warning for Linux-x64 toolset

### DIFF
--- a/build/toolsets/linux-x64.mak
+++ b/build/toolsets/linux-x64.mak
@@ -10,6 +10,7 @@ DLL_SUFFIX        := .so
 DLL_PREFIX        := lib
 DLL_PATH          := LD_LIBRARY_PATH
 COMMON_CFLAGS     += -DLINUX -fPIC
+COMMON_CFLAGS     += -fno-strict-aliasing
 COMMON_LINK_FLAGS += -Wl,-rpath -Wl,'$$ORIGIN'
 LIB_GCC           := ar
 SHELL             := /bin/bash


### PR DESCRIPTION
This patch disables `strict-aliasing` by adding `-fno-strict-aliasing` option.